### PR TITLE
Adds StdDev calculations to FsFreqDbReader

### DIFF
--- a/cs/ENFLookupServer/ENFLookup.test/FsFreqDbReaderTests.cs
+++ b/cs/ENFLookupServer/ENFLookup.test/FsFreqDbReaderTests.cs
@@ -224,4 +224,36 @@ public class FsFreqDbReaderTests
         resultLeague.Results[0].Score.Should().Be(0);
         resultLeague.Results[0].Position.Should().Be(50000);
     }
+    
+    [Fact]
+    public async Task CanGetStandardDeviationOfGrid()
+    {
+        var freqDbReader = new FsFreqDbReader("TestResources/GB_50_Jan2014.freqdb");
+        var end = freqDbReader.FreqDbMetaData.EndDate - freqDbReader.FreqDbMetaData.StartDate;
+        var result1 = await freqDbReader.StdDev();
+        var result2 = await freqDbReader.StdDev(new Tuple<long, long>(0, end));
+        var result3 = await freqDbReader.StdDev(new Tuple<long, long>(- 100000, end + 100000));
+        result1.Should().BeEquivalentTo(result2);
+        result2.Should().BeEquivalentTo(result3);
+        var result4 = await freqDbReader.StdDev(new Tuple<long, long>(100000, 200000));
+        result4.Should().NotBeEquivalentTo(result1);
+        result4.Mean.Should().Be(0.28664000000000001);
+        result4.StdDev.Should().Be(60.564634709626368);
+    }
+    
+    [Fact]
+    public async Task CanGetStandardDeviationOfGrid1stDerivative()
+    {
+        var freqDbReader = new FsFreqDbReader("TestResources/GB_50_Jan2014.freqdb");
+        var end = freqDbReader.FreqDbMetaData.EndDate - freqDbReader.FreqDbMetaData.StartDate;
+        var result1 = await freqDbReader.StdDevDeriv();
+        var result2 = await freqDbReader.StdDevDeriv(new Tuple<long, long>(0, end));
+        var result3 = await freqDbReader.StdDevDeriv(new Tuple<long, long>(- 100000, end + 100000));
+        result1.Should().BeEquivalentTo(result2);
+        result2.Should().BeEquivalentTo(result3);
+        var result4 = await freqDbReader.StdDevDeriv(new Tuple<long, long>(100000, 200000));
+        result4.Should().NotBeEquivalentTo(result1);
+        result4.Mean.Should().Be(0.00093000930009300088);
+        result4.StdDev.Should().Be(2.123914839449117);
+    }
 }

--- a/cs/ENFLookupServer/ENFLookup/MeanStdDev.cs
+++ b/cs/ENFLookupServer/ENFLookup/MeanStdDev.cs
@@ -1,0 +1,10 @@
+namespace ENFLookup;
+
+/// <summary>
+/// Represents the mean and standard deviation of a sample
+/// </summary>
+public class MeanStdDev
+{
+    public double Mean { get; set; }
+    public double StdDev { get; set; }
+}


### PR DESCRIPTION
### What?

Allows `FsFreqDbReader` to calculate it's own mean and standard deviation for the frequency data series and its first derivative across all or part of it's range.

### Why?

It allows us to create more accurate test data for each grid.